### PR TITLE
Remove unsupported PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: php
 
 php:
   - "5.6"
-  - "5.5"
-  - "5.4"
 
 before_script:
   - composer install --dev


### PR DESCRIPTION
Since the [build is failing](https://travis-ci.org/usabilla/api-php) this PR removes PHP versions 5.4 and 5.5 from the Travis configuration.

The readme and composer.json state only PHP 5.6+ is supported.
